### PR TITLE
Fix Probe projectile namespace

### DIFF
--- a/Buffs/BoltsBuff.cs
+++ b/Buffs/BoltsBuff.cs
@@ -2,7 +2,7 @@
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using BocketOfBolts.Projectiles;
+using BucketOfBolts.Projectiles;
 
 namespace BucketOfBolts.Buffs {
     public class BoltsBuff : ModBuff {

--- a/Projectiles/DestroyerProbe1.cs
+++ b/Projectiles/DestroyerProbe1.cs
@@ -7,7 +7,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace BocketOfBolts.Projectiles {
+namespace BucketOfBolts.Projectiles {
     public class DestroyerProbe1 : ModProjectile {
         public virtual Vector2 FlyingOffset => new Vector2(48f * -Main.player[Projectile.owner].direction, -50f);
         public override string Texture => "BucketOfBolts/Projectiles/DestroyerProbe";

--- a/Projectiles/DestroyerProbe2.cs
+++ b/Projectiles/DestroyerProbe2.cs
@@ -7,7 +7,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace BocketOfBolts.Projectiles {
+namespace BucketOfBolts.Projectiles {
     public class DestroyerProbe2 : ModProjectile {
         public virtual Vector2 FlyingOffset => new Vector2(72f * -Main.player[Projectile.owner].direction, -32f);
         public override string Texture => "BucketOfBolts/Projectiles/DestroyerProbe";

--- a/Projectiles/DestroyerProbe3.cs
+++ b/Projectiles/DestroyerProbe3.cs
@@ -7,7 +7,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-namespace BocketOfBolts.Projectiles {
+namespace BucketOfBolts.Projectiles {
     public class DestroyerProbe3 : ModProjectile {
         public virtual Vector2 FlyingOffset => new Vector2(32f * -Main.player[Projectile.owner].direction, -96f);
         public override string Texture => "BucketOfBolts/Projectiles/DestroyerProbe";


### PR DESCRIPTION
Probes were created under the namespace BocketOfBolts.Projectiles - this fixes that, and changes the 'using' statement in the buff to reflect the fix.